### PR TITLE
ConverterRevit: handle missing Revit Location and unknown Revit Roof

### DIFF
--- a/Converters/ConverterRevit/ConverterRevit/Partial Classes/Roof.cs
+++ b/Converters/ConverterRevit/ConverterRevit/Partial Classes/Roof.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Autodesk.Revit.DB;
 using DB = Autodesk.Revit.DB;
 using Roof = Objects.Roof;
@@ -140,10 +140,13 @@ namespace Objects.Converter.Revit
 
       speckleRoof.type = Doc.GetElement(revitRoof.GetTypeId()).Name;
 
-
-      speckleRoof.baseGeometry = profiles[0];
-      if (profiles.Count > 1)
-        speckleRoof.holes = profiles.Skip(1).ToList();
+      // TODO handle case if not one of our supported roofs
+      if ( profiles.Any() )
+      {
+        speckleRoof.baseGeometry = profiles[0];
+        if (profiles.Count > 1)
+          speckleRoof.holes = profiles.Skip(1).ToList();
+      }
 
 
       AddCommonRevitProps(speckleRoof, revitRoof);


### PR DESCRIPTION
There were unhandled exceptions in `Roof` and `Location` that would crash bang the conversions in two cases:
1. if a `RevitRoof` is not a `FootPrintRoof` or an `ExtrusionRoof`
2. if a Revit element has no `Location` prop

This has been fixed by 
1. checking if roof profiles exist before trying to assign them to the `SpeckleRoof.baseGeometry` (profiles are returned as an empty list if the roof is not one of our supported types)
2. returning null in `LocationToSpeckle` if the Revit element does not have a `Location` prop

---
all tests that were passing before still pass after these changes 
I'm also able to convert 5000+ objects from a random Revit sample project without problems 🎉